### PR TITLE
Fix #104: Add explanation in README for <lastmod> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Because the sitemap is added to `site.pages`, you may have to modify any
 templates that iterate through all pages (for example, to build a menu of
 all of the site's content).
 
+## `<lastmod>` tag
+The `<lastmod>` tag in the `sitemap.xml` will reflect by priority:
+
+1.   The modified date of the file as reported by the filesystem if you have `jekyll-last-modified-at` plugin installed (not compatible with Github Pages auto building)
+2.   A personnalised date if you add the variable `last_modified_at:` with a date in the Front Matter
+3.   The creation date of your post (correspondig to the `post.date` variable)
+
 ## Exclusions
 
 If you would like to exclude specific pages/posts from the sitemap set the


### PR DESCRIPTION
I've made some tests and completed the documentation concerning the `<lasmod>` tag, as @pathawks is working on other priorities 😄 (#104)